### PR TITLE
Implemented runtime Camera permissions check for Android 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ navigator.VuforiaPlugin.startVuforia(
   function(data){
     console.log(data);
     alert("Image found: "+data.imageName);
+  },
+  function(data) {
+    alert("Error: " + data);
   }
 );
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-vuforia",
   "description": "Cordova Vuforia Plugin",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "homepage": "https://github.com/mattrayner/cordova-plugin-vuforia",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
         xmlns:rim="http://www.blackberry.com/ns/widgets"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-vuforia"
-        version="1.1.2">
+        version="1.2.0">
     <name>Vuforia</name>
     <description>Cordova Vuforia Plugin</description>
     <license>MIT</license>
@@ -15,7 +15,7 @@
     <author>Matthew Rayner</author>
 
     <info>
-        Cordova Vuforia Plugin version 1.1.2, Copyright (C) 2016 Matthew Rayner
+        Cordova Vuforia Plugin version 1.2.0, Copyright (C) 2016 Matthew Rayner
         Cordova Vuforia Plugin comes with ABSOLUTELY NO WARRANTY; see the
         LICENSE file for more information.
         This is free software, and you are welcome to redistribute it

--- a/src/android/VuforiaPlugin.java
+++ b/src/android/VuforiaPlugin.java
@@ -13,11 +13,20 @@ import org.json.JSONException;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.util.Log;
+import android.Manifest;
+import android.Manifest.permission
 
 import com.mattrayner.vuforia.app.ImageTargets;
 
 public class VuforiaPlugin extends CordovaPlugin {
+    public static final String CAMERA = Manifest.permission.CAMERA;
+    private static final int CAPTURE_VIDEO_ACTIVITY_REQUEST_CODE = 200;
+
+    private static String ACTION;
+    private static JSONArray ARGS;
+
     static final String LOGTAG = "Cordova Vuforia Plugin";
 
     static final int IMAGE_REC_REQUEST = 1;
@@ -29,11 +38,16 @@ public class VuforiaPlugin extends CordovaPlugin {
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
 
+        cordova.requestPermission(this, CAPTURE_VIDEO_ACTIVITY_REQUEST_CODE, CAMERA);
+
         Log.d(LOGTAG, "Plugin initialized.");
     }
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        ACTION = action;
+        ARGS = args;
+
         String targetFile = args.getString(0);
         String targets = args.getJSONArray(1).toString();
         String overlayText = args.getString(2);
@@ -53,10 +67,30 @@ public class VuforiaPlugin extends CordovaPlugin {
         intent.putExtra("OVERLAY_TEXT", overlayText);
         intent.putExtra("LICENSE_KEY", vuforiaLicense);
 
-        // Launch a new activity with Vuforia in it. Expect it to return a result.
-        cordova.startActivityForResult(this, intent, IMAGE_REC_REQUEST);
+        if(cordova.hasPermission(CAMERA)) {
+            // Launch a new activity with Vuforia in it. Expect it to return a result.
+            cordova.startActivityForResult(this, intent, IMAGE_REC_REQUEST);
+        }
+        else {
+            // Request the camera permission and handle the outcome.
+            cordova.requestPermission(this, CAPTURE_VIDEO_ACTIVITY_REQUEST_CODE, CAMERA);
+        }
 
         return true;
+    }
+
+    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
+        for(int r:grantResults) {
+            if(r == PackageManager.PERMISSION_DENIED) {
+                this.callback.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "CAMERA_PERMISSION_ERROR"));
+                return;
+            }
+        }
+        switch(requestCode) {
+            case CAPTURE_VIDEO_ACTIVITY_REQUEST_CODE:
+                execute(ACTION, ARGS, this.callback);
+                break;
+        }
     }
 
     @Override

--- a/www/VuforiaPlugin.js
+++ b/www/VuforiaPlugin.js
@@ -1,5 +1,5 @@
 var VuforiaPlugin = {
-  startVuforia: function(imageFile ,imageTargets, overlayCopy, vuforiaLicense, imageFoundCallback){
+  startVuforia: function(imageFile ,imageTargets, overlayCopy, vuforiaLicense, imageFoundCallback, errorCallback){
 
     cordova.exec(
 
@@ -7,10 +7,11 @@ var VuforiaPlugin = {
       function callback(data) {
         imageFoundCallback(data);
       },
-      // Register the errorHandler
+      // Register the error handler
       function errorHandler(err) {
-        console.error('Vuforia Plugin Error:');
-        console.error(err);
+        if(typeof errorCallback !== 'undefined') {
+          errorCallback(err);
+        }
       },
       // Define what class to route messages to
       'VuforiaPlugin',


### PR DESCRIPTION
* Require Camera permissions on Vuforia start (required for Android 6, fixes #29)
* Handle error and display message mentioning required permission
* Bump version to 1.2.0 