### PR TITLE
Added a dismiss method for the plugin.

### DIFF
--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
@@ -15,6 +15,8 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.BroadcastReceiver;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -54,6 +56,8 @@ import com.mattrayner.vuforia.app.utils.LoadingDialogHandler;
 import com.mattrayner.vuforia.app.utils.ApplicationGLView;
 import com.mattrayner.vuforia.app.utils.Texture;
 
+import com.mattrayner.vuforia.VuforiaPlugin;
+
 public class ImageTargets extends Activity implements ApplicationControl
 {
     private static final String LOGTAG = "ImageTargets";
@@ -87,6 +91,8 @@ public class ImageTargets extends Activity implements ApplicationControl
 
     private RelativeLayout mUILayout;
 
+    private ActionReceiver vuforiaActionReceiver;
+
     LoadingDialogHandler loadingDialogHandler = new LoadingDialogHandler(this);
 
     // Alert Dialog used to display SDK errors
@@ -103,11 +109,31 @@ public class ImageTargets extends Activity implements ApplicationControl
     // Vuforia license key
     String mLicenseKey;
 
+    private class ActionReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context ctx, Intent intent) {
+            String receivedAction = intent.getExtras().getString(VuforiaPlugin.PLUGIN_ACTION);
+
+            if (receivedAction.equals(VuforiaPlugin.DISMISS_ACTION)) {
+                onBackPressed();
+            }
+        }
+    }
+
+
     // Called when the activity first starts or the user navigates back to an
     // activity.
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
+        // if (vuforiaActionReceiver == null){
+        //     vuforiaActionReceiver = new ActionReceiver();
+        //     IntentFilter intentFilter = new IntentFilter(VuforiaPlugin.PLUGIN_ACTION);
+        //     registerReceiver(vuforiaActionReceiver, intentFilter);
+        // }
+
+
         Log.d(LOGTAG, "onCreate");
         super.onCreate(savedInstanceState);
 
@@ -191,10 +217,36 @@ public class ImageTargets extends Activity implements ApplicationControl
         }
     }
 
+
+    @Override
+    protected void onStart()
+    {
+        if (vuforiaActionReceiver == null)
+            vuforiaActionReceiver = new ActionReceiver();
+        IntentFilter intentFilter = new IntentFilter(VuforiaPlugin.PLUGIN_ACTION);
+        registerReceiver(vuforiaActionReceiver, intentFilter);
+
+        Log.d(LOGTAG, "onStart");
+        super.onStart();
+    }
+
+    @Override
+    protected void onStop()
+    {
+        if (vuforiaActionReceiver != null)
+			unregisterReceiver(vuforiaActionReceiver);
+
+        Log.d(LOGTAG, "onStop");
+        super.onStop();
+
+    }
+
     // Called when the activity will start interacting with the user.
     @Override
     protected void onResume()
     {
+
+
         Log.d(LOGTAG, "onResume");
         super.onResume();
 

--- a/src/ios/VuforiaPlugin.h
+++ b/src/ios/VuforiaPlugin.h
@@ -3,5 +3,6 @@
 @interface VuforiaPlugin : CDVPlugin
 
 - (void) cordovaStartVuforia:(CDVInvokedUrlCommand *)command;
+- (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -5,6 +5,7 @@
 
 @property CDVInvokedUrlCommand *command;
 @property ViewController *imageRecViewController;
+@property BOOL startedVuforia;
 
 @end
 
@@ -16,28 +17,30 @@
 
     NSLog(@"Arguments: %@", command.arguments);
     NSLog(@"KEY: %@", [command.arguments objectAtIndex:3]);
-    
+
     [self startVuforiaWithImageTargetFile:[command.arguments objectAtIndex:0] imageTargetNames: [command.arguments objectAtIndex:1] customOverlayText: [command.arguments objectAtIndex:2] vuforiaLicenseKey: [command.arguments objectAtIndex:3]];
     self.command = command;
+
+    self.startedVuforia = true;
 }
 
 #pragma mark - Util_Methods
 - (void) startVuforiaWithImageTargetFile:(NSString *)imageTargetfile imageTargetNames:(NSArray *)imageTargetNames customOverlayText:(NSString *)customOverlayText vuforiaLicenseKey:(NSString *)vuforiaLicenseKey {
-    
+
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"ImageMatched" object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(imageMatched:) name:@"ImageMatched" object:nil];
-    
+
     UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
     self.imageRecViewController = [[ViewController alloc] initWithFileName:imageTargetfile targetNames:imageTargetNames customOverlayText:customOverlayText vuforiaLicenseKey:vuforiaLicenseKey];
-    
+
     [nc pushViewController:self.imageRecViewController animated:YES];
 }
 
 
 - (void)imageMatched:(NSNotification *)notification {
-    
+
     NSDictionary* userInfo = notification.userInfo;
-    
+
     NSLog(@"Vuforia Plugin :: image matched");
     // Create an object with a simple success property.
     NSDictionary *jsonObj = [ [NSDictionary alloc]
@@ -46,16 +49,30 @@
                              @"true", @"success",
                              nil
                              ];
-    
+
     CDVPluginResult *pluginResult = [ CDVPluginResult
                                      resultWithStatus    : CDVCommandStatus_OK
                                      messageAsDictionary : jsonObj
                                      ];
 
+    self.startedVuforia = false;
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
 
     UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
     [nc popToRootViewControllerAnimated:YES];
+
+}
+
+- (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command {
+    if(self.startedVuforia == true){
+        NSLog(@"Vuforia Plugin :: Stop plugin");
+
+        UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
+        [nc popToRootViewControllerAnimated:YES];
+        self.startedVuforia = false;
+    }else{
+        NSLog(@"Vuforia Plugin :: Didn't stop the plugin because it didn't start.");
+    }
 }
 
 @end

--- a/www/VuforiaPlugin.js
+++ b/www/VuforiaPlugin.js
@@ -20,6 +20,26 @@ var VuforiaPlugin = {
       // An array containing one String.
       [ imageFile , imageTargets, overlayCopy, vuforiaLicense ]
     );
+  },
+
+  dismiss: function(success, errorCallback){
+    cordova.exec(
+
+      // Register the callback handler
+        success,
+      // Register the error handler
+      function errorHandler(err) {
+        if(typeof errorCallback !== 'undefined') {
+          errorCallback(err);
+        }
+      },
+      // Define what class to route messages to
+      'VuforiaPlugin',
+      // Execute this method on the above class
+      'cordovaStopVuforia',
+      // An array containing one String.
+      []
+    );
   }
 };
 module.exports = VuforiaPlugin;


### PR DESCRIPTION
We needed the possibility to stop the scan from our app.

For iOS, it's pretty simple, we just pop the viewController, but for android it's pretty different.
So I did my research, and I discovered that BroadcastReceiver can receive simple intent and use them.
So I did some stuff and now we can send a DISMISS_ACTION message to the plugin, and it'll simulate a Back Button Press, so the plugin will close.

That's a pretty big change, tell me if you want me to add some stuff or change some syntaxes.