### PR TITLE
Replaced startVuforia arguments with an option object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ![Cordova-Plugin-Vuforia][logo]
-Cordova-Plugin-Vuforia is a [Cordova][cordova] plugin that uses [Vuforia][vuforia] to perform image recognition. 
+Cordova-Plugin-Vuforia is a [Cordova][cordova] plugin that uses [Vuforia][vuforia] to perform image recognition.
 
 You can see a live example in the [Peugeot 208][peugeot] app on iOS and Android and a basic open source example in the [cordova-vuforia-example][example-repo] repo.
 
@@ -22,7 +22,7 @@ Cordova-Plugin-Vuforia requires the following:
   * If you've already got a project running with an older version of Cordova (e.g. 4 or 5), [see here][updating-cordova] how to update your project's Cordova version.
   * Or if you want to upgrade to the latest version on a platform-by-platform basis, see either [upgrading to cordova-ios 4][upgrading-ios] or [upgrading to cordova-android 5][upgrading-android].
 
-**NOTE:** You will require an Android or iOS device. Cordova-Plugin-Vuforia requires hardware and software support that is not present in either the iOS or Android simulators. 
+**NOTE:** You will require an Android or iOS device. Cordova-Plugin-Vuforia requires hardware and software support that is not present in either the iOS or Android simulators.
 
 
 ## Getting Started
@@ -34,11 +34,15 @@ cordova plugin add cordova-plugin-vuforia
 #### Javascript example
 From within your Javascript file, add the following to launch the [Vuforia][vuforia] plugin.
 ```javascript
+var options = {
+  databaseXmlFile: 'PluginTest.xml',
+  targetList: [ 'logo', 'iceland', 'canterbury-grass', 'brick-lane' ],
+  overlayMessage: 'Point your camera at a test image...',
+  vuforiaLicense: 'YOUR_VUFORIA_KEY'
+};
+
 navigator.VuforiaPlugin.startVuforia(
-  'PluginTest.xml',
-  [ 'logo', 'iceland', 'canterbury-grass', 'brick-lane' ],
-  'Point your camera at a test image...',
-  'YOUR_VUFORIA_KEY',
+  options,
   function(data){
     console.log(data);
     alert("Image found: "+data.imageName);
@@ -49,7 +53,7 @@ navigator.VuforiaPlugin.startVuforia(
 );
 ```
 
-**NOTES**: 
+**NOTES**:
 * You will need to replace `YOUR_VUFORIA_KEY` with a valid license key for the plugin to launch correctly.
 * For testing you can use the `targets/PluginTest_Targets.pdf` file inside the plugin folder; it contains all four testing targets.
 
@@ -77,7 +81,7 @@ Add the following to your `config.xml` file:
 </platform>
 ```
 
-**NOTE:** 
+**NOTE:**
 * File paths can be either from the **resources folder** (which is the default) or **absolute** (in which case you'd start the `src` with `file://`). Absolute paths are useful if you'd like to access files in specific folders, like the iTunes sharing document folder for iOS, or the app root folder for Android.
 
 

--- a/www/VuforiaPlugin.js
+++ b/www/VuforiaPlugin.js
@@ -1,5 +1,9 @@
 var VuforiaPlugin = {
-  startVuforia: function(imageFile ,imageTargets, overlayCopy, vuforiaLicense, imageFoundCallback, errorCallback){
+  startVuforia: function(options, imageFoundCallback, errorCallback){
+    var imageFile = options.databaseXmlFile;
+    var imageTargets = options.targetList;
+    var overlayCopy = options.overlayMessage;
+    var vuforiaLicense = options.vuforiaLicense;
 
     cordova.exec(
 


### PR DESCRIPTION
## Description
Replaced non callback arguments of the `startVuforia` function with a single `options` object containing all named values.
Also changed readme accordingly.

## Motivation and Context
The goal is to allow more options to be added without cluttering the function call.
This also allows easily adding custom options (like in custom versions).

## How Has This Been Tested?
Tested on iOS only but should work on android just fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
