### PR TITLE
Fixed activity result handling on Android.

### DIFF
--- a/src/android/VuforiaPlugin.java
+++ b/src/android/VuforiaPlugin.java
@@ -25,6 +25,10 @@ public class VuforiaPlugin extends CordovaPlugin {
     public static final String PLUGIN_ACTION = "org.cordova.plugin.vuforia.action";
     public static final String DISMISS_ACTION = "dismiss";
 
+    public static final int IMAGE_REC_RESULT = 0;
+    public static final int MANUAL_CLOSE_RESULT = 1;
+    public static final int ERROR_RESULT = 2;
+
     private static final int CAPTURE_VIDEO_ACTIVITY_REQUEST_CODE = 200;
 
     private static String ACTION;
@@ -146,18 +150,22 @@ public class VuforiaPlugin extends CordovaPlugin {
         // Check which request we're responding to
         if (requestCode == IMAGE_REC_REQUEST) {
             // Make sure the request was successful
-            if (resultCode == 0) {
-                try {
-                    JSONObject json = new JSONObject();
-                    json.put("imageName", name);
-                    callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
-                }
-                catch( JSONException e ) {
-                    Log.d(LOGTAG, "JSON ERROR: " + e);
-                }
-            }
-            else {
-                Log.d(LOGTAG, "Error - received code: " + resultCode);
+            switch(resultCode){
+                case IMAGE_REC_RESULT:
+                    try {
+                        JSONObject json = new JSONObject();
+                        json.put("imageName", name);
+                        callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
+                    }
+                    catch( JSONException e ) {
+                        Log.d(LOGTAG, "JSON ERROR: " + e);
+                    }
+                    break;
+                case MANUAL_CLOSE_RESULT:
+                    Log.d(LOGTAG, "Vuforia closed manually.");
+                    break;
+                default:
+                    Log.d(LOGTAG, "Error - received code: " + resultCode);
             }
         }
         vuforiaStarted = false;

--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
@@ -158,7 +158,7 @@ public class ImageTargets extends Activity implements ApplicationControl
         } catch(Exception e) {
             Intent mIntent = new Intent();
             mIntent.putExtra("name", "VUFORIA ERROR");
-            setResult(6, mIntent);
+            setResult(VuforiaPlugin.ERROR_RESULT, mIntent);
             finish();
         }
 
@@ -706,7 +706,7 @@ public class ImageTargets extends Activity implements ApplicationControl
     public void onBackPressed() {
         Intent mIntent = new Intent();
         mIntent.putExtra("name", "CLOSED");
-        setResult(6, mIntent);
+        setResult(VuforiaPlugin.MANUAL_CLOSE_RESULT, mIntent);
         super.onBackPressed();
     }
 


### PR DESCRIPTION
There was a little problem with the vuforia activity, the onBackPressed was returning the same result code than the error.
And in VuforiaPlugin.java, the only result you were treating was the image received one. Other results were considered as error.

So I just added some constants and cleaned this a bit.