### PR TITLE
Close vuforia unification

### DIFF
--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -151,7 +151,7 @@
     NSLog(@"Vuforia Plugin :: button pressed!!!");
     NSDictionary* userInfo = @{@"imageName": @"none"};
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"ImageMatched" object:self userInfo:userInfo];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"CloseRequest" object:self ];
 
 }
 

--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -149,7 +149,6 @@
 
     [self doStopTrackers];
     NSLog(@"Vuforia Plugin :: button pressed!!!");
-    NSDictionary* userInfo = @{@"imageName": @"none"};
 
     [[NSNotificationCenter defaultCenter] postNotificationName:@"CloseRequest" object:self ];
 

--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -29,6 +29,8 @@
 
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"ImageMatched" object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(imageMatched:) name:@"ImageMatched" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"CloseRequest" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(closeRequest:) name:@"CloseRequest" object:nil];
 
     UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
     self.imageRecViewController = [[ViewController alloc] initWithFileName:imageTargetfile targetNames:imageTargetNames customOverlayText:customOverlayText vuforiaLicenseKey:vuforiaLicenseKey];
@@ -55,12 +57,13 @@
                                      messageAsDictionary : jsonObj
                                      ];
 
-    self.startedVuforia = false;
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
+    [self VP_closeView];
 
-    UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
-    [nc popToRootViewControllerAnimated:YES];
+}
 
+- (void)closeRequest:(NSNotification *)notification {
+    [self VP_closeView];
 }
 
 - (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command {
@@ -92,6 +95,11 @@
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
 
+    [self VP_closeView];
+}
+
+
+- (void) VP_closeView {
     if(self.startedVuforia == true){
         UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
         [nc popToRootViewControllerAnimated:YES];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We just noticed that on iOS, when you press the close button, vuforia simulate an image detection, and send a "ImageMatched" notification, to close the plugin.
That's not the case on Android, and that's not really clean.

So I refactored the close view lines, and I created a CloseRequest notification.
Now the close button do exactly what it is meant to do, and the close behavior is the same on Android and iOS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on iPod Touch.
Should work everywhere without any problem.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
