### PR TITLE
Pause and resume methods and autostop option

### DIFF
--- a/src/android/VuforiaPlugin.java
+++ b/src/android/VuforiaPlugin.java
@@ -112,33 +112,19 @@ public class VuforiaPlugin extends CordovaPlugin {
             callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
 
             if(vuforiaStarted) {
-                Intent dismissIntent = new Intent(PLUGIN_ACTION);
-                dismissIntent.putExtra(PLUGIN_ACTION, DISMISS_ACTION);
-
-                this.cordova.getActivity().sendBroadcast(dismissIntent);
+                sendAction(DISMISS_ACTION);
                 vuforiaStarted = false;
             }
         }else if(action.equals("pauseVuforia")){
             Log.d(LOGTAG, "Pausing trackers");
-
-            JSONObject json = new JSONObject();
-            json.put("success", "true");
-            callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
-
-            Intent pauseIntent = new Intent(PLUGIN_ACTION);
-            pauseIntent.putExtra(PLUGIN_ACTION, PAUSE_ACTION);
-            this.cordova.getActivity().sendBroadcast(pauseIntent);
             
+            sendSuccessPluginResult();
+            sendAction(PAUSE_ACTION);
         }else if(action.equals("resumeVuforia")){
             Log.d(LOGTAG, "Resuming trackers");
 
-            JSONObject json = new JSONObject();
-            json.put("success", "true");
-            callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
-
-            Intent resumeIntent = new Intent(PLUGIN_ACTION);
-            resumeIntent.putExtra(PLUGIN_ACTION, RESUME_ACTION);
-            this.cordova.getActivity().sendBroadcast(resumeIntent);
+            sendSuccessPluginResult();
+            sendAction(RESUME_ACTION);
         }
 
         return true;
@@ -194,5 +180,22 @@ public class VuforiaPlugin extends CordovaPlugin {
             }
         }
         vuforiaStarted = false;
+    }
+
+    private void sendAction(String action){
+        Intent resumeIntent = new Intent(PLUGIN_ACTION);
+        resumeIntent.putExtra(PLUGIN_ACTION, action);
+        this.cordova.getActivity().sendBroadcast(resumeIntent);
+    }
+
+    private void sendSuccessPluginResult(){
+        try {
+            JSONObject json = new JSONObject();
+            json.put("success", "true");
+            callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
+        }
+        catch( JSONException e ) {
+            Log.d(LOGTAG, "JSON ERROR: " + e);
+        }
     }
 }

--- a/src/android/VuforiaPlugin.java
+++ b/src/android/VuforiaPlugin.java
@@ -24,6 +24,8 @@ public class VuforiaPlugin extends CordovaPlugin {
     public static final String CAMERA = Manifest.permission.CAMERA;
     public static final String PLUGIN_ACTION = "org.cordova.plugin.vuforia.action";
     public static final String DISMISS_ACTION = "dismiss";
+    public static final String PAUSE_ACTION = "pause";
+    public static final String RESUME_ACTION = "resume";
 
     public static final int IMAGE_REC_RESULT = 0;
     public static final int MANUAL_CLOSE_RESULT = 1;
@@ -65,6 +67,7 @@ public class VuforiaPlugin extends CordovaPlugin {
             String vuforiaLicense = args.getString(3);
             Boolean closeButton = args.getBoolean(4);
             Boolean showDevicesIcon = args.getBoolean(5);
+            Boolean autostopOnImageFound = args.getBoolean(6);
 
             Log.d(LOGTAG, "Args: "+args);
             Log.d(LOGTAG, "Text: "+overlayText);
@@ -80,6 +83,7 @@ public class VuforiaPlugin extends CordovaPlugin {
             intent.putExtra("LICENSE_KEY", vuforiaLicense);
             intent.putExtra("DISPLAY_CLOSE_BUTTON", closeButton);
             intent.putExtra("DISPLAY_DEVICES_ICON", showDevicesIcon);
+            intent.putExtra("STOP_AFTER_IMAGE_FOUND", autostopOnImageFound);
 
             if(cordova.hasPermission(CAMERA)) {
                 // Launch a new activity with Vuforia in it. Expect it to return a result.
@@ -114,6 +118,27 @@ public class VuforiaPlugin extends CordovaPlugin {
                 this.cordova.getActivity().sendBroadcast(dismissIntent);
                 vuforiaStarted = false;
             }
+        }else if(action.equals("pauseVuforia")){
+            Log.d(LOGTAG, "Pausing trackers");
+
+            JSONObject json = new JSONObject();
+            json.put("success", "true");
+            callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
+
+            Intent pauseIntent = new Intent(PLUGIN_ACTION);
+            pauseIntent.putExtra(PLUGIN_ACTION, PAUSE_ACTION);
+            this.cordova.getActivity().sendBroadcast(pauseIntent);
+            
+        }else if(action.equals("resumeVuforia")){
+            Log.d(LOGTAG, "Resuming trackers");
+
+            JSONObject json = new JSONObject();
+            json.put("success", "true");
+            callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, json));
+
+            Intent resumeIntent = new Intent(PLUGIN_ACTION);
+            resumeIntent.putExtra(PLUGIN_ACTION, RESUME_ACTION);
+            this.cordova.getActivity().sendBroadcast(resumeIntent);
         }
 
         return true;

--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargetRenderer.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargetRenderer.java
@@ -1,7 +1,7 @@
 /*===============================================================================
 Copyright (c) 2012-2014 Qualcomm Connected Experiences, Inc. All Rights Reserved.
 
-Vuforia is a trademark of QUALCOMM Incorporated, registered in the United States 
+Vuforia is a trademark of QUALCOMM Incorporated, registered in the United States
 and other countries. Trademarks of QUALCOMM Incorporated are used with permission.
 ===============================================================================*/
 
@@ -31,21 +31,21 @@ import com.mattrayner.vuforia.app.utils.LoadingDialogHandler;
 import com.mattrayner.vuforia.app.utils.Texture;
 
 
-// The renderer class for the ImageTargets sample. 
+// The renderer class for the ImageTargets sample.
 public class ImageTargetRenderer implements GLSurfaceView.Renderer
 {
     private static final String LOGTAG = "ImageTargetRenderer";
-    
+
     private ApplicationSession vuforiaAppSession;
     private ImageTargets mActivity;
 
     private Renderer mRenderer;
-    
+
     boolean mIsActive = false;
 
     String mTargets = "";
-    
-    
+
+
     public ImageTargetRenderer(ImageTargets activity,
         ApplicationSession session, String targets)
     {
@@ -53,71 +53,71 @@ public class ImageTargetRenderer implements GLSurfaceView.Renderer
         vuforiaAppSession = session;
         mTargets = targets;
     }
-    
-    
+
+
     // Called to draw the current frame.
     @Override
     public void onDrawFrame(GL10 gl)
     {
         if (!mIsActive)
             return;
-        
+
         // Call our function to render content
         renderFrame();
     }
-    
-    
+
+
     // Called when the surface is created or recreated.
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config)
     {
         Log.d(LOGTAG, "GLRenderer.onSurfaceCreated");
-        
+
         initRendering();
-        
+
         // Call Vuforia function to (re)initialize rendering after first use
         // or after OpenGL ES context was lost (e.g. after onPause/onResume):
         vuforiaAppSession.onSurfaceCreated();
     }
-    
-    
+
+
     // Called when the surface changed size.
     @Override
     public void onSurfaceChanged(GL10 gl, int width, int height)
     {
         Log.d(LOGTAG, "GLRenderer.onSurfaceChanged");
-        
+
         // Call Vuforia function to handle render surface size changes:
         vuforiaAppSession.onSurfaceChanged(width, height);
     }
-    
-    
+
+
     // Function for initializing the renderer.
     private void initRendering()
     {
         mRenderer = Renderer.getInstance();
-        
+
         GLES20.glClearColor(0.0f, 0.0f, 0.0f, Vuforia.requiresAlpha() ? 0.0f
             : 1.0f);
-        
+
 
         // Hide the Loading Dialog
         mActivity.loadingDialogHandler
             .sendEmptyMessage(LoadingDialogHandler.HIDE_LOADING_DIALOG);
-        
+
     }
-    
-    
+
+
     // The render function.
     private void renderFrame()
     {
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT | GLES20.GL_DEPTH_BUFFER_BIT);
-        
+
         State state = mRenderer.begin();
         mRenderer.drawVideoBackground();
-        
+
         GLES20.glEnable(GLES20.GL_DEPTH_TEST);
-        
+
         // handle face culling, we need to detect if we are using reflection
         // to determine the direction of the culling
         GLES20.glEnable(GLES20.GL_CULL_FACE);
@@ -126,7 +126,7 @@ public class ImageTargetRenderer implements GLSurfaceView.Renderer
             GLES20.glFrontFace(GLES20.GL_CW); // Front camera
         else
             GLES20.glFrontFace(GLES20.GL_CCW); // Back camera
-            
+
         // did we find any trackables this frame?
         for (int tIdx = 0; tIdx < state.getNumTrackableResults(); tIdx++)
         {
@@ -146,14 +146,10 @@ public class ImageTargetRenderer implements GLSurfaceView.Renderer
 
             if (looking_for)
             {
-                Context context =  mActivity.getApplicationContext();
-                Intent resultIntent = new Intent();
-                resultIntent.putExtra("name", obj_name);
-                mActivity.setResult(0, resultIntent);
-                mActivity.finish();
+                mActivity.imageFound(obj_name);
             }
         }
-        
+
         GLES20.glDisable(GLES20.GL_DEPTH_TEST);
 
         mRenderer.end();

--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
@@ -114,6 +114,9 @@ public class ImageTargets extends Activity implements ApplicationControl
     // Display devices icon image
     Boolean mDisplayDevicesIcon;
 
+    // Stop the activity
+    Boolean mAutostopOnImageFound;
+
     // Vuforia license key
     String mLicenseKey;
 
@@ -125,6 +128,10 @@ public class ImageTargets extends Activity implements ApplicationControl
 
             if (receivedAction.equals(VuforiaPlugin.DISMISS_ACTION)) {
                 onBackPressed();
+            }else if(receivedAction.equals(VuforiaPlugin.PAUSE_ACTION)){
+                doStopTrackers();
+            }else if(receivedAction.equals(VuforiaPlugin.RESUME_ACTION)){
+                doStartTrackers();
             }
         }
     }
@@ -168,6 +175,7 @@ public class ImageTargets extends Activity implements ApplicationControl
         mOverlayMessage = intent.getStringExtra("OVERLAY_TEXT");
         mDisplayCloseButton = intent.getBooleanExtra("DISPLAY_CLOSE_BUTTON", true);
         mDisplayDevicesIcon = intent.getBooleanExtra("DISPLAY_DEVICES_ICON", true);
+        mAutostopOnImageFound = intent.getBooleanExtra("STOP_AFTER_IMAGE_FOUND", true);
 
         startLoadingAnimation();
 
@@ -712,5 +720,17 @@ public class ImageTargets extends Activity implements ApplicationControl
 
     public void handleCloseButton(View view){
         onBackPressed();
+    }
+
+    public void imageFound(String imageName){
+        Context context =  this.getApplicationContext();
+        Intent resultIntent = new Intent();
+        resultIntent.putExtra("name", imageName);
+        this.setResult(0, resultIntent);
+
+        doStopTrackers();
+
+        if(mAutostopOnImageFound)
+            this.finish();
     }
 }

--- a/src/ios/ImageTargets/ImageTargetsViewController.h
+++ b/src/ios/ImageTargets/ImageTargetsViewController.h
@@ -35,5 +35,7 @@
 @property (nonatomic) bool delaying;
 
 - (id)initWithOverlayOptions:(NSDictionary *)overlayOptions vuforiaLicenseKey:(NSString *)vuforiaLicenseKey;
+- (bool) doStartTrackers;
+- (bool) doStopTrackers;
 
 @end

--- a/src/ios/ViewController.h
+++ b/src/ios/ViewController.h
@@ -7,6 +7,8 @@
 @property (retain, nonatomic) NSString *overlayText;
 @property (retain, nonatomic) NSString *vuforiaLicenseKey;
 
--(id)initWithFileName:(NSString *)fileName targetNames:(NSArray *)imageTargetNames overlayOptions:(NSString *)overlayOptions vuforiaLicenseKey:(NSString *)vuforiaLicenseKey;
+-(id)initWithFileName:(NSString *)fileName targetNames:(NSArray *)imageTargetNames overlayOptions:(NSDictionary*)overlayOptions vuforiaLicenseKey:(NSString *)vuforiaLicenseKey;
+- (bool) stopTrackers;
+- (bool) startTrackers;
 
 @end

--- a/src/ios/ViewController.mm
+++ b/src/ios/ViewController.mm
@@ -1,10 +1,13 @@
 #import "ViewController.h"
 #import "ImageTargetsViewController.h"
 
+#import <QCAR/TrackerManager.h>
+#import <QCAR/ObjectTracker.h>
 
 @interface ViewController ()
 
 @property BOOL launchedCamera;
+@property ImageTargetsViewController *imageTargetsViewController;
 
 @end
 
@@ -36,19 +39,27 @@
     [super viewDidAppear:animated];
 
     if (self.launchedCamera == false) {
-        ImageTargetsViewController *vc = [[ImageTargetsViewController alloc]  initWithOverlayOptions:self.overlayOptions vuforiaLicenseKey:self.vuforiaLicenseKey];
+        self.imageTargetsViewController = [[ImageTargetsViewController alloc]  initWithOverlayOptions:self.overlayOptions vuforiaLicenseKey:self.vuforiaLicenseKey];
         self.launchedCamera = true;
 
-        vc.imageTargetFile = [self.imageTargets objectForKey:@"imageTargetFile"];
-        vc.imageTargetNames = [self.imageTargets objectForKey:@"imageTargetNames"];
+        self.imageTargetsViewController.imageTargetFile = [self.imageTargets objectForKey:@"imageTargetFile"];
+        self.imageTargetsViewController.imageTargetNames = [self.imageTargets objectForKey:@"imageTargetNames"];
 
-        [self.navigationController pushViewController:vc animated:YES];
+        [self.navigationController pushViewController:self.imageTargetsViewController animated:YES];
     }
 }
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+- (bool) stopTrackers {
+    return [self.imageTargetsViewController doStopTrackers];
+}
+
+- (bool) startTrackers {
+    return [self.imageTargetsViewController doStartTrackers];
 }
 
 - (void)dismissMe {

--- a/src/ios/VuforiaPlugin.h
+++ b/src/ios/VuforiaPlugin.h
@@ -4,5 +4,7 @@
 
 - (void) cordovaStartVuforia:(CDVInvokedUrlCommand *)command;
 - (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command;
+- (void) pauseVuforia:(CDVInvokedUrlCommand *)command;
+- (void) resumeVuforia:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -6,6 +6,7 @@
 @property CDVInvokedUrlCommand *command;
 @property ViewController *imageRecViewController;
 @property BOOL startedVuforia;
+@property BOOL autostopOnImageFound;
 
 @end
 
@@ -20,11 +21,52 @@
 
     NSDictionary *overlayOptions =  [[NSDictionary alloc] initWithObjectsAndKeys: [command.arguments objectAtIndex:2], @"overlayText", [NSNumber numberWithBool:[[command.arguments objectAtIndex:5] integerValue]], @"showDevicesIcon", nil];
 
+    self.autostopOnImageFound = [[command.arguments objectAtIndex:6] integerValue];
 
     [self startVuforiaWithImageTargetFile:[command.arguments objectAtIndex:0] imageTargetNames: [command.arguments objectAtIndex:1] overlayOptions: overlayOptions vuforiaLicenseKey: [command.arguments objectAtIndex:3]];
     self.command = command;
 
     self.startedVuforia = true;
+}
+
+- (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command {
+    self.command = command;
+
+    NSDictionary *jsonObj = [NSDictionary alloc];
+
+    if(self.startedVuforia == true){
+        NSLog(@"Vuforia Plugin :: Stopping plugin");
+
+        jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
+                     @"true", @"success",
+                     nil
+                   ];
+    }else{
+        NSLog(@"Vuforia Plugin :: Cannot stop the plugin because it wasn't started");
+
+        jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
+                     @"false", @"success",
+                     @"No Vuforia session running", @"message",
+                     nil
+                   ];
+    }
+
+    CDVPluginResult *pluginResult = [ CDVPluginResult
+                                     resultWithStatus    : CDVCommandStatus_OK
+                                     messageAsDictionary : jsonObj
+                                    ];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
+
+    [self VP_closeView];
+}
+
+- (void) pauseVuforia:(CDVInvokedUrlCommand *)command{
+    [self.imageRecViewController stopTrackers];
+}
+
+- (void) resumeVuforia:(CDVInvokedUrlCommand *)command{
+    [self.imageRecViewController startTrackers];
 }
 
 #pragma mark - Util_Methods
@@ -61,7 +103,10 @@
                                      ];
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
-    [self VP_closeView];
+
+    if(self.autostopOnImageFound){
+        [self VP_closeView];
+    }
 
 }
 
@@ -69,37 +114,6 @@
     [self VP_closeView];
 }
 
-- (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command {
-    self.command = command;
-
-    NSDictionary *jsonObj = [NSDictionary alloc];
-
-    if(self.startedVuforia == true){
-        NSLog(@"Vuforia Plugin :: Stopping plugin");
-
-        jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
-                     @"true", @"success",
-                     nil
-                   ];
-    }else{
-        NSLog(@"Vuforia Plugin :: Cannot stop the plugin because it wasn't started");
-
-        jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
-                     @"false", @"success",
-                     @"No Vuforia session running", @"message",
-                     nil
-                   ];
-    }
-
-    CDVPluginResult *pluginResult = [ CDVPluginResult
-                                     resultWithStatus    : CDVCommandStatus_OK
-                                     messageAsDictionary : jsonObj
-                                    ];
-
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
-
-    [self VP_closeView];
-}
 
 
 - (void) VP_closeView {

--- a/www/VuforiaPlugin.js
+++ b/www/VuforiaPlugin.js
@@ -34,6 +34,9 @@ var VuforiaPlugin = {
     var vuforiaLicense = options.vuforiaLicense;
     var showAndroidCloseButton = options.showAndroidCloseButton?true:false;
     var showDevicesIcon = options.showDevicesIcon ? true : false;
+    var autostopOnImageFound = true;
+    if (typeof options.autostopOnImageFound !== "undefined" && options.autostopOnImageFound !==null && !options.autostopOnImageFound)
+      autostopOnImageFound = false;
 
     cordova.exec(
       // Register the callback handler
@@ -49,7 +52,7 @@ var VuforiaPlugin = {
       // Execute this method on the above class
       'cordovaStartVuforia',
       // Provide an array of arguments above method
-      [ imageFile , imageTargets, overlayCopy, vuforiaLicense, showAndroidCloseButton, showDevicesIcon ]
+      [ imageFile , imageTargets, overlayCopy, vuforiaLicense, showAndroidCloseButton, showDevicesIcon, autostopOnImageFound ]
     );
   },
 
@@ -73,6 +76,44 @@ var VuforiaPlugin = {
       VuforiaPlugin.pluginClass,
       // Execute this method on the above class
       'cordovaStopVuforia',
+      // Provide an empty array of arguments to the above method
+      []
+    );
+  },
+
+  pauseVuforia: function(success, errorCallback){
+    cordova.exec(
+      // Register the callback handler
+      function callback(data) {
+        success(data);
+      },
+      // Register the error handler
+      function errorHandler(err) {
+        VuforiaPlugin.errorHandler(err, errorCallback);
+      },
+      // Define what class to route messages to
+      VuforiaPlugin.pluginClass,
+      // Execute this method on the above class
+      'pauseVuforia',
+      // Provide an empty array of arguments to the above method
+      []
+    );
+  },
+
+  resumeVuforia: function(success, errorCallback){
+    cordova.exec(
+      // Register the callback handler
+      function callback(data) {
+        success(data);
+      },
+      // Register the error handler
+      function errorHandler(err) {
+        VuforiaPlugin.errorHandler(err, errorCallback);
+      },
+      // Define what class to route messages to
+      VuforiaPlugin.pluginClass,
+      // Execute this method on the above class
+      'resumeVuforia',
       // Provide an empty array of arguments to the above method
       []
     );


### PR DESCRIPTION
## Description
Added a pause and resume method for Vuforia. They'll just stop and start the trackers, so the view will still show the camera, but you'll not be able to detect a target.
It can be really useful if you want some phases where you don't always want the player to scan a target.

Also, I made optional turning off vuforia when an image is found. It's true by default, so it'll change nothing, but if you add `autostopOnImageFound: false` in the options object, it'll just stop trackers when an image is found, and you'll have to stop vuforia manually (with StopVuforia).


## Motivation and Context
After start and stop vuforia methods, a pause and a resume methods where interesting.
And the non-autostop on image found is really useful for us.

## How Has This Been Tested?
Tested on iPod Touch and Galaxy S2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
