### PR TITLE
Add iOS user feedback for starting and stopping trackers

### DIFF
--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -62,11 +62,15 @@
 }
 
 - (void) cordovaStopTrackers:(CDVInvokedUrlCommand *)command{
-    [self.imageRecViewController stopTrackers];
+    bool result = [self.imageRecViewController stopTrackers];
+
+    [self handleResultMessage:result command:command];
 }
 
 - (void) cordovaStartTrackers:(CDVInvokedUrlCommand *)command{
-    [self.imageRecViewController startTrackers];
+    bool result = [self.imageRecViewController startTrackers];
+
+    [self handleResultMessage:result command:command];
 }
 
 #pragma mark - Util_Methods
@@ -114,8 +118,6 @@
     [self VP_closeView];
 }
 
-
-
 - (void) VP_closeView {
     if(self.startedVuforia == true){
         UINavigationController *nc = (UINavigationController *)[UIApplication sharedApplication].keyWindow.rootViewController;
@@ -123,6 +125,37 @@
 
         self.startedVuforia = false;
     }
+}
+
+-(void) handleResultMessage:(bool)result command:(CDVInvokedUrlCommand *)command {
+    if(result){
+        [self sendSuccessMessage:command];
+    } else {
+        [self sendErrorMessage:command];
+    }
+}
+
+-(void) sendSuccessMessage:(CDVInvokedUrlCommand *)command {
+    NSDictionary *jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
+                             @"true", @"success",
+                             nil
+                             ];
+
+    CDVPluginResult *pluginResult = [ CDVPluginResult
+                                     resultWithStatus    : CDVCommandStatus_OK
+                                     messageAsDictionary : jsonObj
+                                     ];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+-(void) sendErrorMessage:(CDVInvokedUrlCommand *)command {
+    CDVPluginResult *pluginResult = [ CDVPluginResult
+                                     resultWithStatus    : CDVCommandStatus_ERROR
+                                     messageAsString: @"Did not successfully complete"
+                                     ];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 @end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added user feedback to the start/stop tracker methods on iOS

## Motivation and Context
At the moment, there's no user feedback when calling start/stop trackers on iOS. There's no way of knowing (from the Cordova side) wether the calls actually worked... Or even did anything...

Fixes #74 

## How Has This Been Tested?
Tested on an iPhone 6s with iOS 10-beta1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.

