### PR TITLE
Mattrayner/allow user to change target list dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can see a live example in the [Peugeot 208][peugeot] app on iOS and Android 
     - [`stopVuforia` - Stop your Vuforia session](#stopvuforia---stop-your-vuforia-session)
     - [`stopVuforiaTrackers` - Stop Vuforia image trackers](#stopvuforiatrackers---stop-vuforia-image-trackers)
     - [`startVuforiaTrackers` - Start Vuforia image trackers](#startvuforiatrackers---start-vuforia-image-trackers)
+    - [`updateVuforiaTargets` - Update the list of targets Vuforia is searching for](#updatevuforiatargets---update-the-list-of-targets-vuforia-is-searching-for)
   - [Using your own data](#using-your-own-data)
     - [`www/targets/`](#wwwtargets)
     - [JavaScript](#javascript-1)
@@ -70,6 +71,7 @@ Method | Description
 [`stopVuforia`][stop-vuforia-doc-link] | **Stop a Vuforia session** - Close the camera and return back to Cordova.
 [`stopVuforiaTrackers`][stop-vuforia-trackers-doc-link] | **Stop the Vuforia tracking system** - Leave the Vuforia camera running, just stop searching for images.
 [`startVuforiaTrackers`][start-vuforia-trackers-doc-link] | **Start the Vuforia tracking system** - Leave the Vuforia camera running and start searching for images again.
+[`updateVuforiaTargets`][update-vuforia-targets-doc-link] | **Update Vuforia target list** - Update the list of images we are searching for, but leave the camera and Vuforia running.
 
 #### `startVuforia` - Start your Vuforia session
 From within your JavaScript file, add the following to launch the [Vuforia][vuforia] session.
@@ -237,6 +239,26 @@ navigator.VuforiaPlugin.startVuforiaTrackers(
 ```
 
 
+#### `updateVuforiaTargets` - Update the list of targets Vuforia is searching for
+From within your JavaScript file, add the following to update the list of images [Vuforia][vuforia] is searching for. `updateVuforiaTargets` takes three options, an array of images you want to scan for, a callback for `success` and a callback for `faliure`.
+
+**Why?** - Well, you may want to change the images you are searching for after launching Vuforia. For example, consider a scenario where a game requires users to scan images one after another in a certain order. For example, a museum app may want you to scan all of the Rembrandt paintings in a room from oldest to newest to unlock some content. This method can offload the burdon of decision from your app to Vuforia, instead of writing login in your JavaScript, we're letting Vuforia take care of it.
+
+```javascript
+navigator.VuforiaPlugin.updateVuforiaTargets(
+    ['iceland', 'canterbury-grass'], // Only return a success if the 'iceland' or 'canterbury-grass' images are found.
+    function(data){
+        console.log(data);
+        
+        alert('Updated trackers');
+    },
+    function(data) {
+        alert("Error: " + data);
+    }
+);
+```
+
+
 ### Using your own data
 We know that eventually you're going to want to use your own data. To do so, follow these extra steps.
 
@@ -314,3 +336,4 @@ Cordova-Plugin-Vuforia is licensed under the [MIT License][info-license].
 [stop-vuforia-doc-link]: #stopvuforia---stop-your-vuforia-session
 [stop-vuforia-trackers-doc-link]: #stopvuforiatrackers---stop-vuforia-image-trackers
 [start-vuforia-trackers-doc-link]: #startvuforiatrackers---start-vuforia-image-trackers
+[update-vuforia-targets-doc-link]: #updatevuforiatargets---update-the-list-of-targets-vuforia-is-searching-for

--- a/src/android/VuforiaPlugin.java
+++ b/src/android/VuforiaPlugin.java
@@ -29,6 +29,7 @@ public class VuforiaPlugin extends CordovaPlugin {
     public static final String DISMISS_ACTION = "dismiss";
     public static final String PAUSE_ACTION = "pause";
     public static final String RESUME_ACTION = "resume";
+    public static final String UPDATE_TARGETS_ACTION = "update_targets";
 
     // Save some ENUM values to describe plugin results
     public static final int IMAGE_REC_RESULT = 0;
@@ -79,6 +80,9 @@ public class VuforiaPlugin extends CordovaPlugin {
         else if(action.equals("cordovaStartTrackers")) {
             startVuforiaTrackers(action, args, callbackContext);
         }
+        else if(action.equals("cordovaUpdateTargets")) {
+            updateVuforiaTargets(action, args, callbackContext);
+        }
         else {
             return false;
         }
@@ -87,7 +91,7 @@ public class VuforiaPlugin extends CordovaPlugin {
     }
 
     // Start our Vuforia activities
-    public void startVuforia(String action, JSONArray args, CallbackContext callbackContext) {
+    public void startVuforia(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         // If we are starting Vuforia, set the public variable referencing our start callback for later use
         VuforiaPlugin.persistantVuforiaStartCallback = callbackContext;
 
@@ -172,6 +176,19 @@ public class VuforiaPlugin extends CordovaPlugin {
         Log.d(LOGTAG, "Resuming trackers");
 
         sendAction(RESUME_ACTION);
+
+        sendSuccessPluginResult();
+    }
+
+    // Start Vuforia trackers
+    public void updateVuforiaTargets(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        Log.d(LOGTAG, "Updating targets");
+
+        Log.d(LOGTAG, "ARGS: "+args);
+
+        String targets = args.getJSONArray(0).toString();
+
+        sendAction(UPDATE_TARGETS_ACTION, targets);
 
         sendSuccessPluginResult();
     }
@@ -272,6 +289,14 @@ public class VuforiaPlugin extends CordovaPlugin {
     private void sendAction(String action){
         Intent resumeIntent = new Intent(PLUGIN_ACTION);
         resumeIntent.putExtra(PLUGIN_ACTION, action);
+        this.cordova.getActivity().sendBroadcast(resumeIntent);
+    }
+
+    // Send a broadcast to our open activity (probably Vuforia)
+    private void sendAction(String action, String data){
+        Intent resumeIntent = new Intent(PLUGIN_ACTION);
+        resumeIntent.putExtra(PLUGIN_ACTION, action);
+        resumeIntent.putExtra("ACTION_DATA", data);
         this.cordova.getActivity().sendBroadcast(resumeIntent);
     }
 

--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargetRenderer.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargetRenderer.java
@@ -155,4 +155,8 @@ public class ImageTargetRenderer implements GLSurfaceView.Renderer
         mRenderer.end();
     }
 
+    public void updateTargetStrings(String targets) {
+        mTargets = targets;
+    }
+
 }

--- a/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
+++ b/src/android/java/com/mattrayner/vuforia/app/ImageTargets.java
@@ -132,6 +132,9 @@ public class ImageTargets extends Activity implements ApplicationControl
                 doStopTrackers();
             }else if(receivedAction.equals(VuforiaPlugin.RESUME_ACTION)){
                 doStartTrackers();
+            }else if(receivedAction.equals(VuforiaPlugin.UPDATE_TARGETS_ACTION)){
+                String targets = intent.getStringExtra("ACTION_DATA");
+                doUpdateTargets(targets);
             }
         }
     }
@@ -746,5 +749,11 @@ public class ImageTargets extends Activity implements ApplicationControl
 
             VuforiaPlugin.sendImageFoundUpdate(imageName);
         }
+    }
+
+    public void doUpdateTargets(String targets) {
+        mTargets = targets;
+
+        mRenderer.updateTargetStrings(mTargets);
     }
 }

--- a/src/ios/ImageTargets/ImageTargetsViewController.h
+++ b/src/ios/ImageTargets/ImageTargetsViewController.h
@@ -37,5 +37,6 @@
 - (id)initWithOverlayOptions:(NSDictionary *)overlayOptions vuforiaLicenseKey:(NSString *)vuforiaLicenseKey;
 - (bool) doStartTrackers;
 - (bool) doStopTrackers;
+- (bool) doUpdateTargets:(NSArray *)targets;
 
 @end

--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -677,4 +677,10 @@
 - (BOOL)prefersStatusBarHidden {
     return YES;
 }
+
+-(bool) doUpdateTargets:(NSArray *)targets {
+    self.imageTargetNames = targets;
+
+    return TRUE;
+}
 @end

--- a/src/ios/ViewController.h
+++ b/src/ios/ViewController.h
@@ -10,5 +10,6 @@
 -(id)initWithFileName:(NSString *)fileName targetNames:(NSArray *)imageTargetNames overlayOptions:(NSDictionary*)overlayOptions vuforiaLicenseKey:(NSString *)vuforiaLicenseKey;
 - (bool) stopTrackers;
 - (bool) startTrackers;
+- (bool) updateTargets:(NSArray *)targets;
 
 @end

--- a/src/ios/ViewController.mm
+++ b/src/ios/ViewController.mm
@@ -62,6 +62,10 @@
     return [self.imageTargetsViewController doStartTrackers];
 }
 
+- (bool) updateTargets:(NSArray *)targets {
+    return [self.imageTargetsViewController doUpdateTargets:targets];
+}
+
 - (void)dismissMe {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"CameraHasFound" object:self];
 }

--- a/src/ios/VuforiaPlugin.h
+++ b/src/ios/VuforiaPlugin.h
@@ -6,5 +6,6 @@
 - (void) cordovaStopVuforia:(CDVInvokedUrlCommand *)command;
 - (void) cordovaStopTrackers:(CDVInvokedUrlCommand *)command;
 - (void) cordovaStartTrackers:(CDVInvokedUrlCommand *)command;
+- (void) cordovaUpdateTargets:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -38,23 +38,23 @@
         NSLog(@"Vuforia Plugin :: Stopping plugin");
 
         jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
-                     @"true", @"success",
-                     nil
+                   @"true", @"success",
+                   nil
                    ];
     }else{
         NSLog(@"Vuforia Plugin :: Cannot stop the plugin because it wasn't started");
 
         jsonObj = [ [NSDictionary alloc] initWithObjectsAndKeys :
-                     @"false", @"success",
-                     @"No Vuforia session running", @"message",
-                     nil
+                   @"false", @"success",
+                   @"No Vuforia session running", @"message",
+                   nil
                    ];
     }
 
     CDVPluginResult *pluginResult = [ CDVPluginResult
                                      resultWithStatus    : CDVCommandStatus_OK
                                      messageAsDictionary : jsonObj
-                                    ];
+                                     ];
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
 
@@ -69,6 +69,29 @@
 
 - (void) cordovaStartTrackers:(CDVInvokedUrlCommand *)command{
     bool result = [self.imageRecViewController startTrackers];
+
+    [self handleResultMessage:result command:command];
+}
+
+- (void) cordovaUpdateTargets:(CDVInvokedUrlCommand *)command{
+    NSArray *targets = [command.arguments objectAtIndex:0];
+
+    // We need to ensure our targets are flatened, if we pass an array of items it'll crash if we dont
+    NSMutableArray *flattenedTargets = [[NSMutableArray alloc] init];
+    for (int i = 0; i < targets.count ; i++)
+    {
+        if([[targets objectAtIndex:i] respondsToSelector:@selector(count)]) {
+            [flattenedTargets addObjectsFromArray:[targets objectAtIndex:i]];
+        } else {
+            [flattenedTargets addObject:[targets objectAtIndex:i]];
+        }
+    }
+
+    targets = [flattenedTargets copy];
+
+    NSLog(@"Updating targets: %@", targets);
+
+    bool result = [self.imageRecViewController updateTargets:targets];
 
     [self handleResultMessage:result command:command];
 }

--- a/www/VuforiaPlugin.js
+++ b/www/VuforiaPlugin.js
@@ -77,6 +77,18 @@ var VuforiaPlugin = {
   },
 
   /**
+   * Update Vuforia image targets.
+   *
+   * @param {Array.<string>} targets An array of images we are going to search for within our database. For example
+   *                                  you may have a database of 100 images, but only be interested in 5 right now.
+   * @param {function} successCallback A callback for when the session is resumed successfully.
+   * @param {function|null} errorCallback A callback for when an error occurs.
+   */
+  updateVuforiaTargets: function(targets, successCallback, errorCallback){
+    VuforiaPlugin.exec(successCallback, errorCallback, 'cordovaUpdateTargets', [ targets ]);
+  },
+
+  /**
    * Handle an error from one of the plugin methods. If a callback is defined, an error message is passed to it. If not,
    * the error message is logged to the console.
    *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added the ability for a user to update the array of images that Vuforia is searching for, after launching the plugin. I've also update the README accordingly

## Motivation and Context
If you have a complicated use case, or your application relies on the ability to scan multiple images in some pre-defied order, this allows you to move a lot of that logic out to Vuforia

Fixes #79 

## How Has This Been Tested?
On an iPhone 6S running iOS 10-beta1 and an LG Nexus running Lollipop

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
