### PR TITLE
HOTFIX iOS overlay text null error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-vuforia",
   "description": "Cordova Vuforia Plugin",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage": "https://github.com/mattrayner/cordova-plugin-vuforia",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
         xmlns:rim="http://www.blackberry.com/ns/widgets"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-vuforia"
-        version="3.0.0">
+        version="3.0.1">
     <name>Vuforia</name>
     <description>Cordova Vuforia Plugin</description>
     <license>MIT</license>
@@ -15,7 +15,7 @@
     <author>Matthew Rayner</author>
 
     <info>
-        Cordova Vuforia Plugin version 3.0.0, Copyright (C) 2016 Matthew Rayner
+        Cordova Vuforia Plugin version 3.0.1, Copyright (C) 2016 Matthew Rayner
         Cordova Vuforia Plugin comes with ABSOLUTELY NO WARRANTY; see the
         LICENSE file for more information.
         This is free software, and you are welcome to redistribute it

--- a/src/ios/VuforiaPlugin.m
+++ b/src/ios/VuforiaPlugin.m
@@ -19,7 +19,9 @@
     NSLog(@"Arguments: %@", command.arguments);
     NSLog(@"KEY: %@", [command.arguments objectAtIndex:3]);
 
-    NSDictionary *overlayOptions =  [[NSDictionary alloc] initWithObjectsAndKeys: [command.arguments objectAtIndex:2], @"overlayText", [NSNumber numberWithBool:[[command.arguments objectAtIndex:5] integerValue]], @"showDevicesIcon", nil];
+    NSString *overlayText = ([command.arguments objectAtIndex:2] == (id)[NSNull null]) ? @"" : [command.arguments objectAtIndex:2];
+
+    NSDictionary *overlayOptions =  [[NSDictionary alloc] initWithObjectsAndKeys: overlayText, @"overlayText", [NSNumber numberWithBool:[[command.arguments objectAtIndex:5] integerValue]], @"showDevicesIcon", nil];
 
     self.autostopOnImageFound = [[command.arguments objectAtIndex:6] integerValue];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With 3.0.0 we missed a test case where the user passes `null` as the overlayText option. We've addressed that in this PR.

## Motivation and Context
The plugin would hard-close when a null value is passed as overlayText in iOS.

## How Has This Been Tested?
iPhone 6S running iOS 10-beta1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
