### PR TITLE
Doesn't display the overlay until you can close Vuforia.

### DIFF
--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -56,7 +56,6 @@
         self.title = @"Image Targets";
 
         // get whether the user opted to show the device icon
-        bool showDevicesIcon = [[self.overlayOptions objectForKey:@"showDevicesIcon"] integerValue];
 
         // Create the EAGLView with the screen dimensions
         CGRect screenBounds = [[UIScreen mainScreen] bounds];
@@ -89,8 +88,20 @@
          selector:@selector(resumeAR)
          name:UIApplicationDidBecomeActiveNotification
          object:nil];
+         [self loadOverlay];
+    }
+    return self;
+}
+
+-(void) loadOverlay {
+    if(!vapp.cameraIsStarted){
+        [self performSelector:@selector(loadOverlay) withObject:nil afterDelay:0.1];
+    }else{
 
         // set up the overlay back bar
+
+        bool showDevicesIcon = [[self.overlayOptions objectForKey:@"showDevicesIcon"] integerValue];
+
         UIView *vuforiaBarView=[[UIView alloc]initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 75)];
         vuforiaBarView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.5f];
         vuforiaBarView.tag = 8;
@@ -162,7 +173,6 @@
             }
         }
     }
-    return self;
 }
 
 -(void)buttonPressed {
@@ -614,7 +624,7 @@
         if(!self.delaying) {
             self.delaying = true;
 
-            [self performSelector:@selector(startVuforia) withObject:nil afterDelay:1];
+
         }
 
         CGRect mainBounds = [[UIScreen mainScreen] bounds];


### PR DESCRIPTION
## Description
The overlay will wait that Vuforia to be closable before displaying

## Motivation and Context
After some use of the plugin, we noticed that if you close vuforia a bit to soon, the plugin completly crash. So we made the overlay to wait until Vuforia can be closed.

## How Has This Been Tested?
Tested on iPad and iPod Touch

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.

