### PR TITLE
Fixed the bug when Vuforia stop working when orientation changes on iOS.

### DIFF
--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -615,18 +615,17 @@
 
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         if(!self.delaying){
-            //[self stopVuforia];
-            [vapp pauseAR:nil];
-
+            [self stopVuforia];
             [self showLoadingAnimation];
         }
     } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         if(!self.delaying) {
             self.delaying = true;
 
-
+            [self performSelector:@selector(startVuforia) withObject:nil afterDelay:1];
         }
 
+        NSLog(@"ROTATING THE SCREEN");
         CGRect mainBounds = [[UIScreen mainScreen] bounds];
 
         UIView *vuforiaBarView = (UIView *)[eaglView viewWithTag:8];
@@ -691,9 +690,8 @@
 
 - (void)stopVuforia
 {
-    //[vapp pauseAR:nil];
-
-    [vapp stopAR:nil];
+    [vapp pauseAR:nil];
+    // [vapp stopAR:nil];
     // Be a good OpenGL ES citizen: now that QCAR is paused and the render
     // thread is not executing, inform the root view controller that the
     // EAGLView should finish any OpenGL ES commands


### PR DESCRIPTION
## Description
We just discovered that Vuforia stop working when the orientation changes.
So I just added few lines that fix that!

## How Has This Been Tested?
Tested on iPod Touch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.

