### PR TITLE
Fix for camera background not covering the whole screen on ios.

### DIFF
--- a/src/ios/ImageTargets/ImageTargetsEAGLView.mm
+++ b/src/ios/ImageTargets/ImageTargetsEAGLView.mm
@@ -1,9 +1,11 @@
 /*===============================================================================
- Copyright (c) 2012-2014 Qualcomm Connected Experiences, Inc. All Rights Reserved.
+Copyright (c) 2016 PTC Inc. All Rights Reserved.
 
- Vuforia is a trademark of QUALCOMM Incorporated, registered in the United States
- and other countries. Trademarks of QUALCOMM Incorporated are used with permission.
- ===============================================================================*/
+Copyright (c) 2012-2015 Qualcomm Connected Experiences, Inc. All Rights Reserved.
+
+Vuforia is a trademark of PTC Inc., registered in the United States and other 
+countries.
+===============================================================================*/
 
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGLES/ES2/gl.h>
@@ -72,7 +74,7 @@
         vapp = app;
         // Enable retina mode if available on this device
         if (YES == [vapp isRetinaDisplay]) {
-            [self setContentScaleFactor:2.0f];
+            [self setContentScaleFactor:[UIScreen mainScreen].nativeScale];
         }
 
         // Create the OpenGL ES context

--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -730,7 +730,8 @@
 }
 
 - (BOOL)shouldAutorotate {
-    return [[self presentingViewController] shouldAutorotate];
+    // return [[self presentingViewController] shouldAutorotate];
+    return NO; // Don't allow rotation while there are issues handling camera view after rotation.
 }
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {

--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -226,7 +226,7 @@
     [vapp initAR:Vuforia::GL_20 orientation:orientation];
     // [vapp initAR:Vuforia::GL_20 ARViewBoundsSize:viewFrame.size orientation:orientation];
 
-    [self performSelector:@selector(test) withObject:nil afterDelay:.5];
+    [self performSelector:@selector(handleResumeComplete) withObject:nil afterDelay:.5];
 }
 
 
@@ -633,12 +633,8 @@
     bool showDevicesIcon = [[self.overlayOptions objectForKey:@"showDevicesIcon"] integerValue];
 
     UIView *vuforiaBarView = (UIView *)[eaglView viewWithTag:8];
-
     UIButton *closeButton = (UIButton *)[eaglView viewWithTag:10];
-    UIActivityIndicatorView *loadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
-
     UILabel *detailLabel = (UILabel *)[eaglView viewWithTag:9];
-    UIActivityIndicatorView *labelLoadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
 
     // handle close button location
     CGRect closeRect = closeButton.frame;

--- a/src/ios/ImageTargets/ImageTargetsViewController.mm
+++ b/src/ios/ImageTargets/ImageTargetsViewController.mm
@@ -223,7 +223,8 @@
     [self showLoadingAnimation];
 
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-    [vapp initAR:Vuforia::GL_20 ARViewBoundsSize:viewFrame.size orientation:orientation];
+    [vapp initAR:Vuforia::GL_20 orientation:orientation];
+    // [vapp initAR:Vuforia::GL_20 ARViewBoundsSize:viewFrame.size orientation:orientation];
 
     [self performSelector:@selector(test) withObject:nil afterDelay:.5];
 }
@@ -608,8 +609,6 @@
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
-    bool showDevicesIcon = [[self.overlayOptions objectForKey:@"showDevicesIcon"] integerValue];
-
     // Code here will execute before the rotation begins.
     // Equivalent to placing it in the deprecated method -[willRotateToInterfaceOrientation:duration:]
 
@@ -617,76 +616,74 @@
         if(!self.delaying){
             //[self stopVuforia];
             [vapp pauseAR:nil];
-
             [self showLoadingAnimation];
         }
+
+        [self updateInterfaceLayout: size];
     } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         if(!self.delaying) {
             self.delaying = true;
-
-
         }
 
-        CGRect mainBounds = [[UIScreen mainScreen] bounds];
-
-        UIView *vuforiaBarView = (UIView *)[eaglView viewWithTag:8];
-
-        UIButton *closeButton = (UIButton *)[eaglView viewWithTag:10];
-        UIActivityIndicatorView *loadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
-
-        UILabel *detailLabel = (UILabel *)[eaglView viewWithTag:9];
-        UIActivityIndicatorView *labelLoadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
-
-        [UIView animateWithDuration:0.33 animations:^{
-
-            // handle close button location
-            CGRect closeRect = closeButton.frame;
-            closeRect.origin.x = [[UIScreen mainScreen] bounds].size.width - 65;
-            closeButton.frame = closeRect;
-
-            // if the device icon is to be shown, adapt the text to fit.
-            CGRect detailFrame = detailLabel.frame;
-            if(showDevicesIcon) {
-                detailFrame = CGRectMake(70, 10, [[UIScreen mainScreen] bounds].size.width - 130, detailLabel.frame.size.height);
-            }
-            else {
-                detailFrame = CGRectMake(20, 10, [[UIScreen mainScreen] bounds].size.width - 130, detailLabel.frame.size.height);
-            }
-            detailLabel.frame = detailFrame;
-            [detailLabel sizeToFit];
-            [vuforiaBarView addSubview:detailLabel];
-
-            CGRect vuforiaFrame = vuforiaBarView.frame;
-            vuforiaFrame.size.height = detailLabel.frame.size.height + 25;
-            vuforiaBarView.frame = vuforiaFrame;
-
-            if(detailLabel.frame.size.height > closeButton.frame.size.height) {
-                CGRect buttonFrame = closeButton.frame;
-                buttonFrame.origin.y = detailLabel.frame.size.height / 3.0;
-                closeButton.frame = buttonFrame;
-            }
-            else {
-                // handle close button location
-                CGRect closeRect = closeButton.frame;
-                closeRect.origin.y = 5;
-                closeButton.frame = closeRect;
-
-                // handle case where text is short
-                vuforiaFrame.size.height = 75;
-                vuforiaBarView.frame = vuforiaFrame;
-            }
-
-            // handle showDevicesIcon if it exists
-            if(showDevicesIcon) {
-                UIImageView *imageView = (UIImageView *)[eaglView viewWithTag:11];
-                CGRect imageFrame = imageView.frame;
-                imageFrame.origin.y = detailLabel.frame.size.height / 3.0;
-                imageView.frame = imageFrame;
-            }
-        }];
-
-
+        [self startVuforia];
     }];
+}
+
+- (void) updateInterfaceLayout:(CGSize)newScreenSize {
+    bool showDevicesIcon = [[self.overlayOptions objectForKey:@"showDevicesIcon"] integerValue];
+
+    UIView *vuforiaBarView = (UIView *)[eaglView viewWithTag:8];
+
+    UIButton *closeButton = (UIButton *)[eaglView viewWithTag:10];
+    UIActivityIndicatorView *loadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
+
+    UILabel *detailLabel = (UILabel *)[eaglView viewWithTag:9];
+    UIActivityIndicatorView *labelLoadingIndicator = (UIActivityIndicatorView *)[eaglView viewWithTag:1];
+
+    // handle close button location
+    CGRect closeRect = closeButton.frame;
+    closeRect.origin.x = newScreenSize.width - 65;
+    closeButton.frame = closeRect;
+
+    // if the device icon is to be shown, adapt the text to fit.
+    CGRect detailFrame = detailLabel.frame;
+    if(showDevicesIcon) {
+        detailFrame = CGRectMake(70, 10, newScreenSize.width - 130, detailLabel.frame.size.height);
+    }
+    else {
+        detailFrame = CGRectMake(20, 10, newScreenSize.width - 130, detailLabel.frame.size.height);
+    }
+    detailLabel.frame = detailFrame;
+    [detailLabel sizeToFit];
+    [vuforiaBarView addSubview:detailLabel];
+
+    CGRect vuforiaFrame = vuforiaBarView.frame;
+    vuforiaFrame.size.height = detailLabel.frame.size.height + 25;
+    vuforiaBarView.frame = vuforiaFrame;
+
+    if(detailLabel.frame.size.height > closeButton.frame.size.height) {
+        CGRect buttonFrame = closeButton.frame;
+        buttonFrame.origin.y = detailLabel.frame.size.height / 3.0;
+        closeButton.frame = buttonFrame;
+    }
+    else {
+        // handle close button location
+        CGRect closeRect = closeButton.frame;
+        closeRect.origin.y = 5;
+        closeButton.frame = closeRect;
+
+        // handle case where text is short
+        vuforiaFrame.size.height = 75;
+        vuforiaBarView.frame = vuforiaFrame;
+    }
+
+    // handle showDevicesIcon if it exists
+    if(showDevicesIcon) {
+        UIImageView *imageView = (UIImageView *)[eaglView viewWithTag:11];
+        CGRect imageFrame = imageView.frame;
+        imageFrame.origin.y = detailLabel.frame.size.height / 3.0;
+        imageView.frame = imageFrame;
+    }
 }
 
 - (void)stopVuforia
@@ -729,12 +726,11 @@
         Vuforia::setRotation(1);
     }
 
-
     // initialize the AR session
     //[vapp initAR:Vuforia::GL_20 ARViewBoundsSize:viewFrame.size orientation:orientation];
     [vapp resumeAR:nil];
 
-    [self performSelector:@selector(test) withObject:nil afterDelay:.5];
+    [self performSelector:@selector(handleResumeComplete) withObject:nil afterDelay:.5];
 }
 
 - (BOOL)shouldAutorotate {
@@ -750,10 +746,8 @@
     return [[self presentingViewController] preferredInterfaceOrientationForPresentation];
 }
 
--(void)test
-{
+-(void)handleResumeComplete {
     self.delaying = false;
-
     [self hideLoadingAnimation];
 }
 
@@ -763,7 +757,6 @@
 
 -(bool) doUpdateTargets:(NSArray *)targets {
     self.imageTargetNames = targets;
-
     return TRUE;
 }
 @end

--- a/src/ios/Utils/ApplicationSession.h
+++ b/src/ios/Utils/ApplicationSession.h
@@ -69,7 +69,7 @@ and other countries. Trademarks of QUALCOMM Incorporated are used with permissio
 - (void) initAR:(int) VuforiaInitFlags ARViewBoundsSize:(CGSize) ARViewBoundsSize orientation:(UIInterfaceOrientation) ARViewOrientation;
 
 // start the AR session
-- (bool) startAR:(Vuforia::CameraDevice::CAMERA) camera error:(NSError **)error;
+- (bool) startAR:(Vuforia::CameraDevice::CAMERA_DIRECTION) camera error:(NSError **)error;
 
 // pause the AR session
 - (bool) pauseAR:(NSError **)error;

--- a/src/ios/Utils/ApplicationSession.h
+++ b/src/ios/Utils/ApplicationSession.h
@@ -66,7 +66,7 @@ and other countries. Trademarks of QUALCOMM Incorporated are used with permissio
 - (id)initWithDelegate:(id<ApplicationControl>) delegate vuforiaLicenseKey:(NSString *) vuforiaLicenseKey;
 
 // initialize the AR library. This is an asynchronous method. When the initialization is complete, the callback method initARDone will be called
-- (void) initAR:(int) VuforiaInitFlags ARViewBoundsSize:(CGSize) ARViewBoundsSize orientation:(UIInterfaceOrientation) ARViewOrientation;
+- (void) initAR:(int) VuforiaInitFlags orientation:(UIInterfaceOrientation) ARViewOrientation;
 
 // start the AR session
 - (bool) startAR:(Vuforia::CameraDevice::CAMERA_DIRECTION) camera error:(NSError **)error;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The camera background doesn't fill the whole screen on ios so i fixed that.
Problem is we're back to having display issues after screen rotation so for now i disabled screen rotation (but at least the plugin is usable).

Breaking change is that rotation is disabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plugin was usuable as is.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on ipad mini 1, ipad mini 2 and ipod touch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
